### PR TITLE
Add login and private messaging features

### DIFF
--- a/Client/src/main/kotlin/Main.kt
+++ b/Client/src/main/kotlin/Main.kt
@@ -1,25 +1,12 @@
 import androidx.compose.desktop.ui.tooling.preview.Preview
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.Card
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.OutlinedTextField
-import androidx.compose.material.Text
+import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MailOutline
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.Key
@@ -29,43 +16,53 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.ApplicationScope
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
+import kotlin.system.exitProcess
 import androidx.lifecycle.viewmodel.compose.viewModel
 import viewmodels.MainViewModel
-import kotlin.text.isNotBlank
-import kotlin.text.trim
 
 @Composable
 @Preview
 fun App(viewModel: MainViewModel = viewModel { MainViewModel() }) {
     MaterialTheme {
-        Column(
-            modifier = Modifier.padding(8.dp).fillMaxSize(),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
+        if (!viewModel.authorized) LoginScreen(viewModel) else ChatScreen(viewModel)
+    }
+}
 
+@Composable
+fun LoginScreen(vm: MainViewModel){
+    Column(modifier = Modifier.padding(8.dp).fillMaxSize(), verticalArrangement = Arrangement.spacedBy(8.dp)){
+        OutlinedTextField(vm.login, { vm.login = it }, label={ Text("Login") })
+        OutlinedTextField(vm.password, { vm.password = it }, label={ Text("Password") })
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)){
+            Button(onClick = { vm.doLogin() }){ Text("Login") }
+            Button(onClick = { vm.doRegister() }){ Text("Register") }
+        }
+        LazyColumn(modifier = Modifier.weight(1f).fillMaxWidth()){
+            items(vm.messages){ MessageCard("", it) }
+        }
+    }
+}
 
-            LazyColumn(
-                modifier = Modifier.weight(1f).fillMaxWidth(),
-                verticalArrangement = Arrangement.Bottom,
-            ) {
-                items(viewModel.messages) {
-                    MessageCard("Отправитель", it)
-                }
-
+@Composable
+fun ChatScreen(viewModel: MainViewModel){
+    Row(modifier = Modifier.padding(8.dp).fillMaxSize(), horizontalArrangement = Arrangement.spacedBy(8.dp)){
+        Column(modifier = Modifier.weight(1f)){
+            LazyColumn(modifier = Modifier.weight(1f).fillMaxWidth(), verticalArrangement = Arrangement.Bottom){
+                items(viewModel.messages){ MessageCard("", it) }
             }
-            Input(
-                viewModel.inputText,
-                Modifier.fillMaxWidth().padding(8.dp),
-                onInput = { viewModel.inputText = it },
-            ) {
-                if (viewModel.inputText.isNotBlank()) {
-                    viewModel.messages.add(viewModel.inputText.trim())
+            Input(viewModel.inputText, Modifier.fillMaxWidth().padding(8.dp), onInput = { viewModel.inputText = it }){
+                if (viewModel.inputText.isNotBlank()){
+                    viewModel.messages.add("Me->${viewModel.selectedUser ?: "all"}: ${viewModel.inputText.trim()}")
                     viewModel.sendMessage(viewModel.inputText.trim())
                     viewModel.inputText = ""
                 }
+            }
+        }
+        LazyColumn(modifier = Modifier.width(150.dp).fillMaxHeight()){
+            items(viewModel.users){ u ->
+                Text(u, modifier = Modifier.fillMaxWidth().padding(4.dp).clickable { viewModel.selectedUser = u })
             }
         }
     }
@@ -78,10 +75,11 @@ fun MessageCard(
     modifier: Modifier = Modifier,
 ){
     Column {
-        Text(
-            "$senderName:",
-            modifier = Modifier.padding(top = 8.dp, start = 0.dp, end = 0.dp, bottom = 0.dp)
-        )
+        if (senderName.isNotBlank())
+            Text(
+                "$senderName:",
+                modifier = Modifier.padding(top = 8.dp)
+            )
         Card(
             backgroundColor = MaterialTheme.colors.primary,
             contentColor = MaterialTheme.colors.onPrimary,
@@ -130,7 +128,7 @@ fun Input(
 }
 
 fun main() = application(true) {
-    Window(onCloseRequest = ::exitApplication) {
+    Window(onCloseRequest = { exitProcess(0) }) {
         App()
     }
 }

--- a/Client/src/main/kotlin/ru/smak/chat/Client.kt
+++ b/Client/src/main/kotlin/ru/smak/chat/Client.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import java.net.InetSocketAddress
 import java.nio.channels.AsynchronousSocketChannel
-import java.util.*
 import kotlin.coroutines.suspendCoroutine
 
 class Client(
@@ -46,5 +45,9 @@ class Client(
     fun sendMessage(message: String)=clientScope.launch {
         if (message.isNotBlank())
             communicator.sendMessage(message)
+    }
+
+    fun sendCommand(cmd: String)=clientScope.launch {
+        communicator.sendMessage(cmd)
     }
 }

--- a/Client/src/main/kotlin/ru/smak/viewmodels/MainViewModel.kt
+++ b/Client/src/main/kotlin/ru/smak/viewmodels/MainViewModel.kt
@@ -10,11 +10,50 @@ import ru.smak.chat.Client
 class MainViewModel : ViewModel() {
     var inputText by mutableStateOf("")
     val messages = mutableStateListOf<String>()
+    val users = mutableStateListOf<String>()
+
+    var login by mutableStateOf("")
+    var password by mutableStateOf("")
+    var authorized by mutableStateOf(false)
+    var selectedUser by mutableStateOf<String?>(null)
+
     private val client = Client("localhost",5204)
-    fun sendMessage(message: String)=client.sendMessage(message)
+    fun sendMessage(message: String){
+        if (selectedUser != null)
+            client.sendCommand("MSG ${selectedUser!!} $message")
+        else
+            client.sendCommand("BROADCAST $message")
+    }
+
+    fun requestUsers(){
+        client.sendCommand("LIST")
+    }
+
+    fun doLogin(){
+        client.sendCommand("LOGIN $login $password")
+    }
+
+    fun doRegister(){
+        client.sendCommand("REGISTER $login $password")
+    }
+
     init {
-        client.addMessageListener {
-            messages.add(it)
+        client.addMessageListener { handleMessage(it) }
+    }
+
+    private fun handleMessage(m: String){
+        when {
+            m.startsWith("LOGINOK") -> { authorized = true; requestUsers() }
+            m.startsWith("LOGINFAIL") -> { messages.add(m) }
+            m.startsWith("USERS ") -> {
+                val list = m.removePrefix("USERS ")
+                users.clear()
+                if (list.isNotBlank()) users.addAll(list.split(","))
+            }
+            m.startsWith("MSG ") -> {
+                messages.add(m.removePrefix("MSG "))
+            }
+            else -> messages.add(m)
         }
     }
 }

--- a/Server/src/ru/smak/chat/ConnectedClient.kt
+++ b/Server/src/ru/smak/chat/ConnectedClient.kt
@@ -3,32 +3,105 @@ package ru.smak.chat
 import kotlinx.coroutines.*
 import java.nio.channels.AsynchronousSocketChannel
 
-class ConnectedClient(socket: AsynchronousSocketChannel) {
+class ConnectedClient(private val socket: AsynchronousSocketChannel) {
 
     private val communicator = Communicator(socket)
     private var userName: String? = null
     private val clientScope = CoroutineScope(Dispatchers.IO)
 
-    init{
-        connectedClients.add(this)
+    init {
         communicator.start { message -> parse(message) }
     }
 
-    private fun parse(message: String){
-        sendToAll(message, echo = false)
+    private fun parse(message: String) {
+        val parts = message.trim().split(" ", limit = 2)
+        when(parts[0]){
+            "REGISTER" -> {
+                val p = parts.getOrNull(1)?.split(" ", limit = 2)
+                if (p != null && p.size == 2){
+                    if (UserRegistry.register(p[0], p[1])) {
+                        userName = p[0]
+                        connectedClients[p[0]] = this
+                        send("LOGINOK")
+                        sendOffline()
+                        updateUserLists()
+                    } else send("LOGINFAIL already_registered")
+                } else send("LOGINFAIL bad_format")
+            }
+            "LOGIN" -> {
+                val p = parts.getOrNull(1)?.split(" ", limit = 2)
+                if (p != null && p.size == 2){
+                    if (UserRegistry.check(p[0], p[1]) && !connectedClients.containsKey(p[0])) {
+                        userName = p[0]
+                        connectedClients[p[0]] = this
+                        send("LOGINOK")
+                        sendOffline()
+                        updateUserLists()
+                    } else send("LOGINFAIL wrong")
+                } else send("LOGINFAIL bad_format")
+            }
+            "MSG" -> {
+                val u = userName ?: return
+                val p = parts.getOrNull(1)?.split(" ", limit = 2) ?: return
+                if (p.size == 2) sendPrivate(u, p[0], p[1])
+            }
+            "BROADCAST" -> {
+                val u = userName ?: return
+                parts.getOrNull(1)?.let { sendToAll("MSG $u $it", true) }
+            }
+            "LIST" -> {
+                sendUserList()
+            }
+            "LOGOUT" -> {
+                stop()
+            }
+        }
+    }
+
+    private fun sendOffline(){
+        val u = userName ?: return
+        UserRegistry.popOfflineMessages(u).forEach { (from,msg) ->
+            send("MSG $from $msg")
+        }
+    }
+
+    fun send(msg: String){
+        clientScope.launch { communicator.sendMessage(msg) }
     }
 
     fun stop(){
         communicator.stop()
-    }
-
-    private fun sendToAll(message: String, echo: Boolean = true){
-        connectedClients.forEach {
-            if (echo || it != this) clientScope.launch { it.communicator.sendMessage(message) }
+        userName?.let {
+            connectedClients.remove(it)
+            updateUserLists()
         }
     }
 
+    private fun sendPrivate(from: String, to: String, msg: String){
+        val rcpt = connectedClients[to]
+        if (rcpt != null){
+            rcpt.send("MSG $from $msg")
+        } else {
+            UserRegistry.addOfflineMessage(to, from, msg)
+        }
+    }
+
+    private fun sendToAll(message: String, includeSelf: Boolean = false){
+        connectedClients.values.forEach {
+            if (includeSelf || it != this) it.send(message)
+        }
+    }
+
+    private fun sendUserList(){
+        val list = connectedClients.keys.joinToString(",")
+        send("USERS $list")
+    }
+
+    private fun updateUserLists(){
+        connectedClients.values.forEach { it.sendUserList() }
+    }
+
     companion object {
-        private val connectedClients = mutableListOf<ConnectedClient>()
+        private val connectedClients = mutableMapOf<String, ConnectedClient>()
     }
 }

--- a/Server/src/ru/smak/chat/UserRegistry.kt
+++ b/Server/src/ru/smak/chat/UserRegistry.kt
@@ -1,0 +1,72 @@
+package ru.smak.chat
+
+import java.io.File
+import java.util.Base64
+
+object UserRegistry {
+    private val usersFile = File("users.txt")
+    private val offlineFile = File("offline.txt")
+    private val users = mutableMapOf<String, String>()
+    private val offline = mutableMapOf<String, MutableList<Pair<String,String>>>()
+
+    init {
+        if (usersFile.exists()) {
+            usersFile.forEachLine {
+                val parts = it.split(":", limit = 2)
+                if (parts.size == 2) users[parts[0]] = parts[1]
+            }
+        }
+        if (offlineFile.exists()) {
+            offlineFile.forEachLine {
+                val parts = it.split("|", limit = 3)
+                if (parts.size == 3) {
+                    val msg = String(Base64.getDecoder().decode(parts[2]))
+                    offline.computeIfAbsent(parts[0]) { mutableListOf() }.
+                        add(parts[1] to msg)
+                }
+            }
+        }
+    }
+
+    @Synchronized
+    fun register(login: String, password: String): Boolean {
+        if (login in users) return false
+        users[login] = password
+        saveUsers()
+        return true
+    }
+
+    @Synchronized
+    fun check(login: String, password: String): Boolean =
+        users[login] == password
+
+    @Synchronized
+    fun addOfflineMessage(user: String, from: String, msg: String) {
+        offline.computeIfAbsent(user) { mutableListOf() }.add(from to msg)
+        saveOffline()
+    }
+
+    @Synchronized
+    fun popOfflineMessages(user: String): List<Pair<String,String>> {
+        val list = offline.remove(user) ?: emptyList()
+        saveOffline()
+        return list
+    }
+
+    private fun saveUsers() {
+        usersFile.printWriter().use { pw ->
+            users.forEach { (u,p) -> pw.println("$u:$p") }
+        }
+    }
+
+    private fun saveOffline() {
+        offlineFile.printWriter().use { pw ->
+            offline.forEach { (u, msgs) ->
+                msgs.forEach { (from, msg) ->
+                    val enc = Base64.getEncoder().encodeToString(msg.toByteArray())
+                    pw.println("$u|$from|$enc")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add user registration and offline messaging on the server
- handle login, user lists and private messaging on clients
- show login screen and list of users in client UI
- fix build by replacing `exitApplication` with `exitProcess`

## Testing
- `./gradlew --no-daemon assemble`

------
https://chatgpt.com/codex/tasks/task_e_6845bcce70b0832385cd889450cfea44