### PR TITLE
Add comments and general chat selection

### DIFF
--- a/Client/src/main/kotlin/Main.kt
+++ b/Client/src/main/kotlin/Main.kt
@@ -1,25 +1,12 @@
 import androidx.compose.desktop.ui.tooling.preview.Preview
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.Card
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.OutlinedTextField
-import androidx.compose.material.Text
+import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MailOutline
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.Key
@@ -29,67 +16,90 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.ApplicationScope
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
+import kotlin.system.exitProcess
 import androidx.lifecycle.viewmodel.compose.viewModel
 import viewmodels.MainViewModel
-import kotlin.text.isNotBlank
-import kotlin.text.trim
+import viewmodels.ChatMessage
 
+/** Entry point composable that switches between login screen and chat screen. */
 @Composable
 @Preview
 fun App(viewModel: MainViewModel = viewModel { MainViewModel() }) {
     MaterialTheme {
-        Column(
-            modifier = Modifier.padding(8.dp).fillMaxSize(),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
+        if (!viewModel.authorized) LoginScreen(viewModel) else ChatScreen(viewModel)
+    }
+}
 
+@Composable
+/** Screen shown before authentication. */
+fun LoginScreen(vm: MainViewModel){
+    Column(modifier = Modifier.padding(8.dp).fillMaxSize(), verticalArrangement = Arrangement.spacedBy(8.dp)){
+        OutlinedTextField(vm.login, { vm.login = it }, label={ Text("Login") })
+        OutlinedTextField(vm.password, { vm.password = it }, label={ Text("Password") })
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)){
+            Button(onClick = { vm.doLogin() }){ Text("Login") }
+            Button(onClick = { vm.doRegister() }){ Text("Register") }
+        }
+        // Show all service messages from the server
+        LazyColumn(modifier = Modifier.weight(1f).fillMaxWidth()){ 
+            items(vm.messages){ MessageCard("", it) } 
+        }
+    }
+}
 
-            LazyColumn(
-                modifier = Modifier.weight(1f).fillMaxWidth(),
-                verticalArrangement = Arrangement.Bottom,
-            ) {
-                items(viewModel.messages) {
-                    MessageCard("Отправитель", it)
-                }
-
+@Composable
+/** Main chat UI shown after login. */
+fun ChatScreen(viewModel: MainViewModel){
+    Row(modifier = Modifier.padding(8.dp).fillMaxSize(), horizontalArrangement = Arrangement.spacedBy(8.dp)){
+        Column(modifier = Modifier.weight(1f)){
+            // Messages list
+            LazyColumn(modifier = Modifier.weight(1f).fillMaxWidth(), verticalArrangement = Arrangement.Bottom){
+                items(viewModel.messages){ MessageCard("", it) }
             }
-            Input(
-                viewModel.inputText,
-                Modifier.fillMaxWidth().padding(8.dp),
-                onInput = { viewModel.inputText = it },
-            ) {
-                if (viewModel.inputText.isNotBlank()) {
-                    viewModel.messages.add(viewModel.inputText.trim())
+            Input(viewModel.inputText, Modifier.fillMaxWidth().padding(8.dp), onInput = { viewModel.inputText = it }){
+                if (viewModel.inputText.isNotBlank()){
+                    // Add message locally before sending
+                    viewModel.messages.add(ChatMessage("Me->${viewModel.selectedUser ?: "all"}: ${viewModel.inputText.trim()}", true))
                     viewModel.sendMessage(viewModel.inputText.trim())
                     viewModel.inputText = ""
                 }
+            }
+        }
+        // List of users that can be selected as message recipients
+        LazyColumn(modifier = Modifier.width(150.dp).fillMaxHeight()){
+            items(viewModel.users){ u ->
+                Text(u, modifier = Modifier.fillMaxWidth().padding(4.dp).clickable {
+                    viewModel.selectedUser = if (u == "General") null else u
+                })
             }
         }
     }
 }
 
 @Composable
+/** Card displaying a single chat message. */
 fun MessageCard(
     senderName: String,
-    messageText: String,
+    message: ChatMessage,
     modifier: Modifier = Modifier,
 ){
     Column {
-        Text(
-            "$senderName:",
-            modifier = Modifier.padding(top = 8.dp, start = 0.dp, end = 0.dp, bottom = 0.dp)
-        )
+        if (senderName.isNotBlank())
+            Text(
+                "$senderName:",
+                modifier = Modifier.padding(top = 8.dp)
+            )
         Card(
-            backgroundColor = MaterialTheme.colors.primary,
+            // Lighter color is used for our own messages
+            backgroundColor = if (message.own) MaterialTheme.colors.primary.copy(alpha = 0.6f) else MaterialTheme.colors.primary,
             contentColor = MaterialTheme.colors.onPrimary,
             elevation = 3.dp,
             modifier = Modifier.padding(top = 8.dp)
         ) {
             Text(
-                messageText,
+                message.text,
                 modifier = Modifier.padding(16.dp),
             )
         }
@@ -97,6 +107,7 @@ fun MessageCard(
 }
 
 @Composable
+/** Reusable component for text input with Enter key handling. */
 fun Input(
     value: String,
     modifier: Modifier = Modifier,
@@ -129,8 +140,9 @@ fun Input(
     }
 }
 
+/** Desktop entry point launching the Compose application. */
 fun main() = application(true) {
-    Window(onCloseRequest = ::exitApplication) {
+    Window(onCloseRequest = { exitProcess(0) }) {
         App()
     }
 }

--- a/Client/src/main/kotlin/ru/smak/chat/Client.kt
+++ b/Client/src/main/kotlin/ru/smak/chat/Client.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import java.net.InetSocketAddress
 import java.nio.channels.AsynchronousSocketChannel
-import java.util.*
 import kotlin.coroutines.suspendCoroutine
 
 class Client(
@@ -46,5 +45,9 @@ class Client(
     fun sendMessage(message: String)=clientScope.launch {
         if (message.isNotBlank())
             communicator.sendMessage(message)
+    }
+
+    fun sendCommand(cmd: String)=clientScope.launch {
+        communicator.sendMessage(cmd)
     }
 }

--- a/Client/src/main/kotlin/ru/smak/viewmodels/MainViewModel.kt
+++ b/Client/src/main/kotlin/ru/smak/viewmodels/MainViewModel.kt
@@ -7,14 +7,85 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import ru.smak.chat.Client
 
+/** Data class describing a message shown in chat. */
+data class ChatMessage(
+    /** Text that will be displayed in the UI. */
+    val text: String,
+    /** Indicates that the message was written by the current user. */
+    val own: Boolean = false,
+)
+
+/** View model holding all UI state of the chat client. */
 class MainViewModel : ViewModel() {
+    /** Text currently typed by the user. */
     var inputText by mutableStateOf("")
-    val messages = mutableStateListOf<String>()
+    /** List of chat messages to display. */
+    val messages = mutableStateListOf<ChatMessage>()
+    /** List of online users plus the general chat channel. */
+    val users = mutableStateListOf<String>()
+
+    /** Login and password entered by the user. */
+    var login by mutableStateOf("")
+    var password by mutableStateOf("")
+    /** Flag indicating that the user passed authentication. */
+    var authorized by mutableStateOf(false)
+    /** Null means chat in the general channel, otherwise selected user. */
+    var selectedUser by mutableStateOf<String?>(null)
+
+    /** Client used for network communication with the server. */
     private val client = Client("localhost",5204)
-    fun sendMessage(message: String)=client.sendMessage(message)
+    /**
+     * Send message either privately to selected user or to the general chat
+     * when no user is selected.
+     */
+    fun sendMessage(message: String){
+        if (selectedUser != null)
+            client.sendCommand("MSG ${selectedUser!!} $message")
+        else
+            client.sendCommand("BROADCAST $message")
+    }
+
+    /** Ask server for a list of connected users. */
+    fun requestUsers(){
+        client.sendCommand("LIST")
+    }
+
+    /** Try to login using provided credentials. */
+    fun doLogin(){
+        client.sendCommand("LOGIN ${login.trim()} ${password.trim()}")
+    }
+
+    /** Try to create a new account on the server. */
+    fun doRegister(){
+        client.sendCommand("REGISTER ${login.trim()} ${password.trim()}")
+    }
+
     init {
-        client.addMessageListener {
-            messages.add(it)
+        // Listen for messages from the server and forward them to the handler
+        client.addMessageListener { handleMessage(it) }
+    }
+
+    /**
+     * Parse messages received from the server and update state accordingly.
+     */
+    private fun handleMessage(m: String){
+        when {
+            // Successful authentication
+            m.startsWith("LOGINOK") -> { authorized = true; requestUsers() }
+            // Authentication problems or registration errors
+            m.startsWith("LOGINFAIL") -> { messages.add(ChatMessage(m)) }
+            // Server sends a comma separated list of online users
+            m.startsWith("USERS ") -> {
+                val list = m.removePrefix("USERS ")
+                users.clear()
+                users.add("General")
+                if (list.isNotBlank()) users.addAll(list.split(","))
+            }
+            // Incoming chat message
+            m.startsWith("MSG ") -> {
+                messages.add(ChatMessage(m.removePrefix("MSG ")))
+            }
+            else -> messages.add(ChatMessage(m))
         }
     }
 }

--- a/Server/src/ru/smak/chat/ConnectedClient.kt
+++ b/Server/src/ru/smak/chat/ConnectedClient.kt
@@ -3,32 +3,123 @@ package ru.smak.chat
 import kotlinx.coroutines.*
 import java.nio.channels.AsynchronousSocketChannel
 
-class ConnectedClient(socket: AsynchronousSocketChannel) {
+/**
+ * Represents a single connected client and handles all communication with it.
+ */
+class ConnectedClient(private val socket: AsynchronousSocketChannel) {
 
     private val communicator = Communicator(socket)
     private var userName: String? = null
     private val clientScope = CoroutineScope(Dispatchers.IO)
 
-    init{
-        connectedClients.add(this)
+    init {
+        // Start listening for incoming messages from this client
         communicator.start { message -> parse(message) }
     }
 
-    private fun parse(message: String){
-        sendToAll(message, echo = false)
-    }
-
-    fun stop(){
-        communicator.stop()
-    }
-
-    private fun sendToAll(message: String, echo: Boolean = true){
-        connectedClients.forEach {
-            if (echo || it != this) clientScope.launch { it.communicator.sendMessage(message) }
+    /**
+     * Parse a single command from the client and execute it.
+     */
+    private fun parse(message: String) {
+        val parts = message.trim().split(" ", limit = 2)
+        when(parts[0]){
+            "REGISTER" -> {
+                val p = parts.getOrNull(1)?.split(" ", limit = 2)
+                if (p != null && p.size == 2){
+                    if (UserRegistry.register(p[0], p[1])) {
+                        userName = p[0]
+                        connectedClients[p[0]] = this
+                        send("LOGINOK")
+                        sendOffline()
+                        updateUserLists()
+                    } else send("LOGINFAIL already_registered")
+                } else send("LOGINFAIL bad_format")
+            }
+            "LOGIN" -> {
+                val p = parts.getOrNull(1)?.split(" ", limit = 2)
+                if (p != null && p.size == 2){
+                    if (UserRegistry.check(p[0], p[1]) && !connectedClients.containsKey(p[0])) {
+                        userName = p[0]
+                        connectedClients[p[0]] = this
+                        send("LOGINOK")
+                        sendOffline()
+                        updateUserLists()
+                    } else send("LOGINFAIL wrong")
+                } else send("LOGINFAIL bad_format")
+            }
+            "MSG" -> {
+                val u = userName ?: return
+                val p = parts.getOrNull(1)?.split(" ", limit = 2) ?: return
+                if (p.size == 2) sendPrivate(u, p[0], p[1])
+            }
+            "BROADCAST" -> {
+                val u = userName ?: return
+                // Broadcast to other users; we already display our own message locally
+                parts.getOrNull(1)?.let { sendToAll("MSG $u $it", false) }
+            }
+            "LIST" -> {
+                sendUserList()
+            }
+            "LOGOUT" -> {
+                stop()
+            }
         }
     }
 
+    /** Send all queued offline messages to the client once they log in. */
+    private fun sendOffline(){
+        val u = userName ?: return
+        UserRegistry.popOfflineMessages(u).forEach { (from,msg) ->
+            send("MSG $from $msg")
+        }
+    }
+
+    /** Enqueue a message to be sent asynchronously. */
+    fun send(msg: String){
+        clientScope.launch { communicator.sendMessage(msg) }
+    }
+
+    /** Stop communication and remove client from the list of connected users. */
+    fun stop(){
+        communicator.stop()
+        userName?.let {
+            connectedClients.remove(it)
+            updateUserLists()
+        }
+    }
+
+    /**
+     * Deliver a private message. If recipient is offline it will be saved for
+     * later delivery.
+     */
+    private fun sendPrivate(from: String, to: String, msg: String){
+        val rcpt = connectedClients[to]
+        if (rcpt != null){
+            rcpt.send("MSG $from $msg")
+        } else {
+            UserRegistry.addOfflineMessage(to, from, msg)
+        }
+    }
+
+    /** Broadcast a message to all connected clients. */
+    private fun sendToAll(message: String, includeSelf: Boolean = false){
+        connectedClients.values.forEach {
+            if (includeSelf || it != this) it.send(message)
+        }
+    }
+
+    /** Send list of currently connected users to this client. */
+    private fun sendUserList(){
+        val list = connectedClients.keys.joinToString(",")
+        send("USERS $list")
+    }
+
+    /** Inform every client that the set of online users has changed. */
+    private fun updateUserLists(){
+        connectedClients.values.forEach { it.sendUserList() }
+    }
+
     companion object {
-        private val connectedClients = mutableListOf<ConnectedClient>()
+        private val connectedClients = mutableMapOf<String, ConnectedClient>()
     }
 }

--- a/Server/src/ru/smak/chat/UserRegistry.kt
+++ b/Server/src/ru/smak/chat/UserRegistry.kt
@@ -1,0 +1,92 @@
+package ru.smak.chat
+
+import java.io.File
+import java.util.Base64
+
+/**
+ * Keeps persistent information about registered users and their undelivered
+ * private messages. Data is stored in simple text files so that the server can
+ * be restarted without losing information.
+ */
+object UserRegistry {
+    /** File where "login:password" pairs are stored. */
+    private val usersFile = File("users.txt")
+    /** File with offline messages in format user|from|base64(message). */
+    private val offlineFile = File("offline.txt")
+    private val users = mutableMapOf<String, String>()
+    private val offline = mutableMapOf<String, MutableList<Pair<String,String>>>()
+
+    init {
+        // Load registered users
+        if (usersFile.exists()) {
+            usersFile.forEachLine {
+                val parts = it.split(":", limit = 2)
+                if (parts.size == 2) users[parts[0]] = parts[1]
+            }
+        }
+        // Load saved offline messages
+        if (offlineFile.exists()) {
+            offlineFile.forEachLine {
+                val parts = it.split("|", limit = 3)
+                if (parts.size == 3) {
+                    val msg = String(Base64.getDecoder().decode(parts[2]))
+                    offline.computeIfAbsent(parts[0]) { mutableListOf() }.
+                        add(parts[1] to msg)
+                }
+            }
+        }
+    }
+
+    @Synchronized
+    /** Register a new user. Returns false if login already exists. */
+    fun register(login: String, password: String): Boolean {
+        val l = login.trim()
+        val p = password.trim()
+        if (l in users) return false
+        users[l] = p
+        saveUsers()
+        return true
+    }
+
+    @Synchronized
+    /** Verify user credentials. */
+    fun check(login: String, password: String): Boolean {
+        val l = login.trim()
+        val p = password.trim()
+        return users[l] == p
+    }
+
+    @Synchronized
+    /** Store a private message for delivery when user comes online. */
+    fun addOfflineMessage(user: String, from: String, msg: String) {
+        offline.computeIfAbsent(user) { mutableListOf() }.add(from to msg)
+        saveOffline()
+    }
+
+    @Synchronized
+    /** Retrieve and remove all queued offline messages for a user. */
+    fun popOfflineMessages(user: String): List<Pair<String,String>> {
+        val list = offline.remove(user) ?: emptyList()
+        saveOffline()
+        return list
+    }
+
+    /** Persist the user list to disk. */
+    private fun saveUsers() {
+        usersFile.printWriter().use { pw ->
+            users.forEach { (u,p) -> pw.println("$u:$p") }
+        }
+    }
+
+    /** Persist queued offline messages to disk. */
+    private fun saveOffline() {
+        offlineFile.printWriter().use { pw ->
+            offline.forEach { (u, msgs) ->
+                msgs.forEach { (from, msg) ->
+                    val enc = Base64.getEncoder().encodeToString(msg.toByteArray())
+                    pw.println("$u|$from|$enc")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- document chat client and server code with basic comments
- trim credentials before sending to the server and before verifying
- add `General` item in user list to return from private chat
- highlight user's own messages with a lighter color
- avoid echoing broadcast messages back to the sender

## Testing
- `./gradlew --no-daemon assemble`


------
https://chatgpt.com/codex/tasks/task_e_6845bcce70b0832385cd889450cfea44